### PR TITLE
Add OSGi metadata to the S2 geometry library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 target/
 .project
 .classpath
+.settings

--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,28 @@
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing,
+#    software distributed under the License is distributed on an
+#    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied.  See the License for the
+#    specific language governing permissions and limitations
+#    under the License.
+
+
+# We do not import javax.annotation as these are findbugs 
+# annotations that aren't needed at runtime. In fact, as the
+# findbugs annotations aren't a complete version of the 
+# javax.annotation they are impossible to safely consume.
+
+# We also exclude com.google.errorprone.annotations as the
+# annotations are not needed at runtime
+
+Import-Package: \
+ !javax.annotation, \
+ !com.google.errorprone.annotations, \
+ *
+ 
+-exportcontents: *;version=${project.version}

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <guava.version>25.1-jre</guava.version>
     <jsr305.version>3.0.1</jsr305.version>
     <junit.version>4.13</junit.version>
+    <bnd.version>5.3.0</bnd.version>
   </properties>
 
   <scm>
@@ -158,6 +159,19 @@
       </plugin>
 
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>${bnd.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>3.0.1</version>
@@ -181,6 +195,16 @@
           <serverId>sonatype-nexus-staging</serverId>
           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
           <autoReleaseAfterClose>false</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
In order to use this library in an OSGi framework it needs to include OSGi metadata. Rather than users having to repackage the code, it would be easier if the library jar already contained OSGi bundle metadata.