### PR TITLE
Issue 43: Build error due to guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <revision>HEAD-SNAPSHOT</revision>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <guava.version>32.0-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <errorprone.version>2.19.1</errorprone.version>
     <jsr305.version>3.0.2</jsr305.version>
     <jsinterop.version>2.0.0</jsinterop.version>


### PR DESCRIPTION
This fixes the build error mentioned in [issue 43](https://github.com/google/s2-geometry-library-java/issues/43).