### PR TITLE
Add support for publishing packages to github

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to GitHub Packages
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Publish to GitHub Packages
+        run: mvn --batch-mode -Drevision=${{ github.event.release.tag_name }} -DaltDeploymentRepository=github::https://maven.pkg.github.com/${{ github.repository }} deploy -pl library
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ Parameters for the benchmarks can be passed on the command line. For example, to
 run just the S2Loop benchmarks,
 ```java -jar benchmarks/target/benchmarks.jar S2Loop```
 
+## Maven Repository Management
+
+GitHub Packages requires authentication, even for public packages. Add a
+`<server>` entry to your Maven `settings.xml` with your GitHub username and a
+[personal access token](https://github.com/settings/tokens) that has the
+`read:packages` scope. This file is located at `~/.m2/settings.xml` on macOS
+and Linux, or `%USERPROFILE%\.m2\settings.xml` on Windows:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
 ## S2 implementations
 
 The S2 library has implementations in several languages. In addition to this


### PR DESCRIPTION
Fix for https://github.com/google/s2-geometry-library-java/issues/40

This PR adds a GitHub workflow file that creates the package in GitHub. Note that to read/download packages from GitHub, users will need to provide GitHub credentials (downside of GH vs Maven).