### PR TITLE
Remove incorrect test lines

### DIFF
--- a/tests/tests/com/google/common/geometry/S2CellUnionTest.java
+++ b/tests/tests/com/google/common/geometry/S2CellUnionTest.java
@@ -264,9 +264,6 @@ public class S2CellUnionTest extends GeometryTestCase {
             assertEquals(1, u.size());
             assertEquals(yId, u.cellId(0));
           } else if (yId.contains(xId)) {
-            if (!u.contains(xId)) {
-              u.getIntersection(xCells, yId);
-            }
             assertTrue(u.contains(xId));
           }
         }


### PR DESCRIPTION
Fixes #1 

Small change to remove three un-needed lines in the unit tests. I re-ran the tests and confirmed tests still pass